### PR TITLE
Linux updates

### DIFF
--- a/DVDAuth/_linux/defineForLinux.h
+++ b/DVDAuth/_linux/defineForLinux.h
@@ -13,16 +13,7 @@ typedef unsigned short      UINT16, *PUINT16;
 typedef unsigned int        UINT32, *PUINT32;
 typedef unsigned long long  UINT64, *PUINT64, ULONGLONG;
 
-#if defined(__x86_64__)
-typedef long long INT_PTR, *PINT_PTR;
-typedef unsigned long long UINT_PTR, *PUINT_PTR;
-
-typedef long long LONG_PTR, * PLONG_PTR;
-typedef unsigned long long ULONG_PTR, *PULONG_PTR;
-
-#define __int3264   __int64
-
-#else
+#if defined(_WIN32)
 typedef _W64 int INT_PTR, * PINT_PTR;
 typedef _W64 unsigned int UINT_PTR, * PUINT_PTR;
 
@@ -30,6 +21,15 @@ typedef _W64 long LONG_PTR, * PLONG_PTR;
 typedef _W64 unsigned long ULONG_PTR, * PULONG_PTR;
 
 #define __int3264   __int32
+
+#else
+typedef long long INT_PTR, *PINT_PTR;
+typedef unsigned long long UINT_PTR, *PUINT_PTR;
+
+typedef long long LONG_PTR, * PLONG_PTR;
+typedef unsigned long long ULONG_PTR, *PULONG_PTR;
+
+#define __int3264   __int64
 
 #endif
 

--- a/DVDAuth/makefile
+++ b/DVDAuth/makefile
@@ -1,0 +1,48 @@
+TARGET := DVDAuth_linux.out
+INCFLAGS := -I. -Ilibdvdcpxm/src -I_linux
+CFLAGS := -include _linux/defineForLinux.h
+CXXFLAGS := $(CFLAGS) -std=c++11
+
+ifneq ($(SANITIZER),)
+   CFLAGS   := -fsanitize=$(SANITIZER) $(CFLAGS)
+   CXXFLAGS := -fsanitize=$(SANITIZER) $(CXXFLAGS)
+   LDFLAGS  := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+ifeq ($(DEBUG), 1)
+	CFLAGS += -O0 -g
+	CXXFLAGS += -O0 -g
+else
+	CFLAGS += -O2 -Wall -Wextra -Wno-unknown-pragmas
+	CXXFLAGS += -O2 -Wall -Wextra -Wno-unknown-pragmas
+endif
+
+SOURCES_CXX := \
+  DVDAuth.o \
+  execScsiCmdforFileSystem.o \
+  libdvdcpxm/src/dvd_css.o \
+  libdvdcpxm/src/dvd_command.o \
+  libdvdcpxm/src/dvd_device.o \
+  libdvdcpxm/src/libdvdcpxm.o \
+  _linux/defineForLinux.o
+
+OBJECTS := $(SOURCES_C:.c=.o) $(SOURCES_CXX:.cpp=.o)
+
+all: $(TARGET)
+$(TARGET): $(OBJECTS)
+	$(CXX) -o $@ $(OBJECTS) $(LDFLAGS) $(LIBS)
+
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS) $(INCFLAGS)
+
+%.o: %.cpp
+	$(CXX) -c -o $@ $< $(CXXFLAGS) $(INCFLAGS)
+
+clean-objs:
+	rm -f $(OBJECTS)
+
+clean:
+	rm -f $(OBJECTS)
+	rm -f $(TARGET)
+
+.PHONY: clean clean-objs


### PR DESCRIPTION
Some updates for Linux compat.

- Added a makefile to bring this project inline with the eccedc and dic projects (borrowed the eccedc one)
- Switched up the defined statement in `defineForLinux.h` so this wouldn't try to use `_W64` on non x86_64 platforms (e.g. arm)

We've included DIC in RetroNAS so people can rip their collection to their retro storage, target platform for RetroNAS is rpi so arm support was need for this tool.

Not my forte so perhaps there is a better way to do what i've done here, I've had reports this works fine on rpi 64b but I don't have the usb hardware available to confirm.